### PR TITLE
[TASK] Set GeoPoint function fromAddress to static

### DIFF
--- a/src/AnthonyMartin/GeoLocation/GeoPoint.php
+++ b/src/AnthonyMartin/GeoLocation/GeoPoint.php
@@ -151,7 +151,7 @@ class GeoPoint {
    * @throws UnexpectedResponseException if Google sends us something that we don't expect. we only like nice presents not 500 errors and the like
    * @throws NoApiKeyException if you forget to pass a google API key. create one at https://console.cloud.google.com for Geocoding API
    */
-  static function fromAddress($address, $apiKey=null) {
+  public static function fromAddress($address, $apiKey=null) {
     if (!$apiKey) {
       throw new NoApiKeyException();
     }

--- a/src/AnthonyMartin/GeoLocation/GeoPoint.php
+++ b/src/AnthonyMartin/GeoLocation/GeoPoint.php
@@ -151,7 +151,7 @@ class GeoPoint {
    * @throws UnexpectedResponseException if Google sends us something that we don't expect. we only like nice presents not 500 errors and the like
    * @throws NoApiKeyException if you forget to pass a google API key. create one at https://console.cloud.google.com for Geocoding API
    */
-  public function fromAddress($address, $apiKey=null) {
+  static function fromAddress($address, $apiKey=null) {
     if (!$apiKey) {
       throw new NoApiKeyException();
     }


### PR DESCRIPTION
Change to static function make it possible to run unit test on it.

fromAdress is defined as public function but can only accessed as static function. That always breaks unit testing, as a deprecation notice is throw.
